### PR TITLE
Support file import on mac, windows and linux

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,5 +1,5 @@
-<?php require('Assets\head.php') ?>
-<?php require('Assets\navbar.php') ?>
+<?php require('Assets/head.php') ?>
+<?php require('Assets/navbar.php') ?>
 <section class="home-slider owl-carousel">
       <div class="slider-item bread-item" style="background-image: url('Assets/images/bg_1.jpg');" data-stellar-background-ratio="0.5">
         <div class="overlay"></div>
@@ -116,6 +116,6 @@
         </div>
       </div>
     </section>
-<?php require('Assets\foot.php') ?>
+<?php require('Assets/foot.php') ?>
 <
-<?php require('Assets\footer.php') ?>
+<?php require('Assets/footer.php') ?>

--- a/contact.php
+++ b/contact.php
@@ -1,5 +1,5 @@
-<?php require('Assets\head.php') ?>
-<?php require('Assets\navbar.php') ?>
+<?php require('Assets/head.php') ?>
+<?php require('Assets/navbar.php') ?>
 
 <section class="home-slider owl-carousel">
   <div class="slider-item bread-item" style="background-image: url('Assets/images/bg_1.jpg');" data-stellar-background-ratio="0.5">
@@ -61,6 +61,6 @@
   </div>
 </section>
 
-<?php require('Assets\foot.php') ?>
+<?php require('Assets/foot.php') ?>
 
-<?php require('Assets\footer.php') ?>
+<?php require('Assets/footer.php') ?>

--- a/doctors.php
+++ b/doctors.php
@@ -1,5 +1,5 @@
-<?php require('Assets\head.php') ?>
-<?php require('Assets\navbar.php') ?>
+<?php require('Assets/head.php') ?>
+<?php require('Assets/navbar.php') ?>
 <section class="home-slider owl-carousel">
       <div class="slider-item bread-item" style="background-image: url('Assets/images/bg_1.jpg');" data-stellar-background-ratio="0.5">
         <div class="overlay"></div>
@@ -172,6 +172,6 @@
     	</div>
     </section>
 
-<?php require('Assets\foot.php') ?>
+<?php require('Assets/foot.php') ?>
 
-<?php require('Assets\footer.php') ?>
+<?php require('Assets/footer.php') ?>

--- a/edit_user.php
+++ b/edit_user.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require('Assets/connection.php');
-require('Assets\head.php') ;
+require('Assets/head.php') ;
 if (!isset($_SESSION['admin_email'])) {
     header("Location: admin_login.php");
     exit;
@@ -73,4 +73,4 @@ include('admin_navbar.php'); ?>
         </form>
     </div>
         </section>
-    <?php require('Assets\footer.php') ; ?>
+    <?php require('Assets/footer.php') ; ?>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
-<?php require('Assets\head.php') ?>
-<?php require('Assets\navbar.php') ?>
+<?php require('Assets/head.php') ?>
+<?php require('Assets/navbar.php') ?>
     
 
 <section class="home-slider owl-carousel">
@@ -696,6 +696,6 @@
     </section>
 		
 		<div></div>
-    <?php require('Assets\foot.php') ?>
+    <?php require('Assets/foot.php') ?>
    
-    <?php require('Assets\footer.php') ?>
+    <?php require('Assets/footer.php') ?>

--- a/manage_appointments.php
+++ b/manage_appointments.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require('Assets/connection.php');
-require('Assets\head.php') ;
+require('Assets/head.php') ;
 
 if (!isset($_SESSION['admin_email'])) {
     header("Location: admin_login.php");
@@ -30,7 +30,7 @@ include('admin_navbar.php'); ?>
         <div class="text-right mb-3">
             <a href="appointment_reports.php" class="btn btn-success">📊 View Report</a>
         </div>
-
+        
         <div class="table-responsive">
             <table class="table table-striped table-bordered table-hover">
                 <thead class="thead-dark">
@@ -65,4 +65,4 @@ include('admin_navbar.php'); ?>
         </div>
     </div>
                 </section>
-                <?php require('Assets\footer.php') ; ?>
+                <?php require('Assets/footer.php') ; ?>

--- a/manage_doctors.php
+++ b/manage_doctors.php
@@ -64,4 +64,4 @@ include('admin_navbar.php');
         </div>
 </div>
 </section>
-<?php require('Assets\footer.php') ; ?>
+<?php require('Assets/footer.php') ; ?>

--- a/manage_users.php
+++ b/manage_users.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 require('Assets/connection.php');
-require('Assets\head.php') ;
+require('Assets/head.php') ;
 
 if (!isset($_SESSION['admin_email'])) {
     header("Location: admin_login.php");
@@ -63,4 +63,4 @@ if (isset($_GET['delete'])) {
     </section>
     
 
-   <?php require('Assets\footer.php') ; ?>
+   <?php require('Assets/footer.php') ; ?>

--- a/services.php
+++ b/services.php
@@ -1,5 +1,5 @@
-<?php require('Assets\head.php') ?>
-<?php require('Assets\navbar.php') ?>
+<?php require('Assets/head.php') ?>
+<?php require('Assets/navbar.php') ?>
 
 <section class="home-slider owl-carousel">
   <div class="slider-item bread-item" style="background-image: url('Assets/images/bg_2.jpg');" data-stellar-background-ratio="0.5">
@@ -198,5 +198,5 @@
   </div>
 </section>
 
-<?php require('Assets\foot.php') ?>
-<?php require('Assets\footer.php') ?>
+<?php require('Assets/foot.php') ?>
+<?php require('Assets/footer.php') ?>

--- a/signup.php
+++ b/signup.php
@@ -88,7 +88,7 @@ if ($conn->query($sql) === TRUE) {
     
 }
 $conn->close();
-require('Assets\foot.php');
+require('Assets/foot.php');
 require('Assets/footer.php');
 ?>
  


### PR DESCRIPTION
windows accept forward slash(\) while importing php file on another php file. However, mac and linux does not support forward slash. So, backward slash(/) is universal.

For eg: **<?php require('/Assets/connection.php') ?>** on the top of the php file. 
